### PR TITLE
Feat/local storage

### DIFF
--- a/src/data/protocols/cache/set-storage.ts
+++ b/src/data/protocols/cache/set-storage.ts
@@ -1,0 +1,3 @@
+export interface SetStorage {
+  set: (key: string, value: any) => Promise<void>
+}

--- a/src/data/test/mock-storage.ts
+++ b/src/data/test/mock-storage.ts
@@ -1,6 +1,6 @@
 import { SetStorage } from '../protocols/cache/set-storage'
 
-export class SetStorageSpy implements SetStorage {
+export class SetStorageMock implements SetStorage {
   key: string
   value: any
 

--- a/src/data/test/mock-storage.ts
+++ b/src/data/test/mock-storage.ts
@@ -1,0 +1,11 @@
+import { SetStorage } from '../protocols/cache/set-storage'
+
+export class SetStorageSpy implements SetStorage {
+  key: string
+  value: any
+
+  async set (key: string, value: any): Promise<void> {
+    this.key = key
+    this.value = value
+  }
+}

--- a/src/data/usecases/save-access-token/local-save-access-token.spec.ts
+++ b/src/data/usecases/save-access-token/local-save-access-token.spec.ts
@@ -24,4 +24,11 @@ describe('LocalSaveAccessToken', () => {
     expect(setStorageMock.key).toBe('accessToken')
     expect(setStorageMock.value).toBe(accessToken)
   })
+
+  test('Should throw if SetStorage throws', async () => {
+    const { sut, setStorageMock } = makeSut()
+    jest.spyOn(setStorageMock, 'set').mockRejectedValueOnce(new Error())
+    const promise = sut.save(faker.datatype.uuid())
+    await expect(promise).rejects.toThrow(new Error())
+  })
 })

--- a/src/data/usecases/save-access-token/local-save-access-token.spec.ts
+++ b/src/data/usecases/save-access-token/local-save-access-token.spec.ts
@@ -2,10 +2,23 @@ import { LocalSaveAccessToken } from './local-save-access-token'
 import { SetStorageSpy } from '@/data/test/mock-storage'
 import faker from 'faker'
 
+type SutTypes = {
+  sut: LocalSaveAccessToken
+  setStorageSpy: SetStorageSpy
+}
+
+const makeSut = (): SutTypes => {
+  const setStorageSpy = new SetStorageSpy()
+  const sut = new LocalSaveAccessToken(setStorageSpy)
+  return {
+    sut,
+    setStorageSpy
+  }
+}
+
 describe('LocalSaveAccessToken', () => {
   test('Should call SetStorage with correct value', async () => {
-    const setStorageSpy = new SetStorageSpy()
-    const sut = new LocalSaveAccessToken(setStorageSpy)
+    const { sut, setStorageSpy } = makeSut()
     const accessToken = faker.datatype.uuid()
     await sut.save(accessToken)
     expect(setStorageSpy.key).toBe('accessToken')

--- a/src/data/usecases/save-access-token/local-save-access-token.spec.ts
+++ b/src/data/usecases/save-access-token/local-save-access-token.spec.ts
@@ -1,27 +1,27 @@
 import { LocalSaveAccessToken } from './local-save-access-token'
-import { SetStorageSpy } from '@/data/test/mock-storage'
+import { SetStorageMock } from '@/data/test/mock-storage'
 import faker from 'faker'
 
 type SutTypes = {
   sut: LocalSaveAccessToken
-  setStorageSpy: SetStorageSpy
+  setStorageMock: SetStorageMock
 }
 
 const makeSut = (): SutTypes => {
-  const setStorageSpy = new SetStorageSpy()
-  const sut = new LocalSaveAccessToken(setStorageSpy)
+  const setStorageMock = new SetStorageMock()
+  const sut = new LocalSaveAccessToken(setStorageMock)
   return {
     sut,
-    setStorageSpy
+    setStorageMock
   }
 }
 
 describe('LocalSaveAccessToken', () => {
   test('Should call SetStorage with correct value', async () => {
-    const { sut, setStorageSpy } = makeSut()
+    const { sut, setStorageMock } = makeSut()
     const accessToken = faker.datatype.uuid()
     await sut.save(accessToken)
-    expect(setStorageSpy.key).toBe('accessToken')
-    expect(setStorageSpy.value).toBe(accessToken)
+    expect(setStorageMock.key).toBe('accessToken')
+    expect(setStorageMock.value).toBe(accessToken)
   })
 })

--- a/src/data/usecases/save-access-token/local-save-access-token.spec.ts
+++ b/src/data/usecases/save-access-token/local-save-access-token.spec.ts
@@ -1,0 +1,14 @@
+import { LocalSaveAccessToken } from './local-save-access-token'
+import { SetStorageSpy } from '@/data/test/mock-storage'
+import faker from 'faker'
+
+describe('LocalSaveAccessToken', () => {
+  test('Should call SetStorage with correct value', async () => {
+    const setStorageSpy = new SetStorageSpy()
+    const sut = new LocalSaveAccessToken(setStorageSpy)
+    const accessToken = faker.datatype.uuid()
+    await sut.save(accessToken)
+    expect(setStorageSpy.key).toBe('accessToken')
+    expect(setStorageSpy.value).toBe(accessToken)
+  })
+})

--- a/src/data/usecases/save-access-token/local-save-access-token.ts
+++ b/src/data/usecases/save-access-token/local-save-access-token.ts
@@ -1,0 +1,10 @@
+import { SetStorage } from '@/data/protocols/cache/set-storage'
+import { SaveAccessToken } from '@/domain/usecases/save-access-token'
+
+export class LocalSaveAccessToken implements SaveAccessToken {
+  constructor (private readonly setStorage: SetStorage) {}
+
+  async save (accessToken: string): Promise<void> {
+    await this.setStorage.set('accessToken', accessToken)
+  }
+}

--- a/src/domain/usecases/index.ts
+++ b/src/domain/usecases/index.ts
@@ -1,1 +1,2 @@
 export * from './authentication'
+export * from './save-access-token'

--- a/src/domain/usecases/save-access-token.ts
+++ b/src/domain/usecases/save-access-token.ts
@@ -1,0 +1,3 @@
+export interface SaveAccessToken {
+  save: (acessToken: string) => Promise<void>
+}

--- a/src/infra/cache/local-storage-adapter.spec.ts
+++ b/src/infra/cache/local-storage-adapter.spec.ts
@@ -1,0 +1,17 @@
+import faker from 'faker'
+import 'jest-localstorage-mock'
+import { LocalStorageAdapter } from './local-storage-adapter'
+
+describe('LocalStorageAdapter', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  test('Should call localStorage with correct values', async () => {
+    const sut = new LocalStorageAdapter()
+    const key = faker.database.column()
+    const value = faker.random.word()
+    await sut.set(key, value)
+    expect(localStorage.setItem).toHaveBeenCalledWith(key, value)
+  })
+})

--- a/src/infra/cache/local-storage-adapter.spec.ts
+++ b/src/infra/cache/local-storage-adapter.spec.ts
@@ -2,13 +2,14 @@ import faker from 'faker'
 import 'jest-localstorage-mock'
 import { LocalStorageAdapter } from './local-storage-adapter'
 
+const makeSut = (): LocalStorageAdapter => new LocalStorageAdapter()
 describe('LocalStorageAdapter', () => {
   beforeEach(() => {
     localStorage.clear()
   })
 
   test('Should call localStorage with correct values', async () => {
-    const sut = new LocalStorageAdapter()
+    const sut = makeSut()
     const key = faker.database.column()
     const value = faker.random.word()
     await sut.set(key, value)

--- a/src/infra/cache/local-storage-adapter.ts
+++ b/src/infra/cache/local-storage-adapter.ts
@@ -1,0 +1,7 @@
+import { SetStorage } from '@/data/protocols/cache/set-storage'
+
+export class LocalStorageAdapter implements SetStorage {
+  async set (key: string, value: any): Promise<void> {
+    localStorage.setItem(key, value)
+  }
+}

--- a/src/main/factories/cache/local-storage-adapter-factory.ts
+++ b/src/main/factories/cache/local-storage-adapter-factory.ts
@@ -1,0 +1,6 @@
+import { SetStorage } from '@/data/protocols/cache/set-storage'
+import { LocalStorageAdapter } from '@/infra/cache/local-storage-adapter'
+
+export const makeLocalStorageAdapter = (): SetStorage => {
+  return new LocalStorageAdapter()
+}

--- a/src/main/factories/http/api-url-factory.ts
+++ b/src/main/factories/http/api-url-factory.ts
@@ -1,3 +1,3 @@
 export const makeApiUrl = (path: string): string => {
-  return `process.env.API_URL${path}`
+  return `${process.env.API_URL}${path}`
 }

--- a/src/main/factories/pages/login/login-factory.tsx
+++ b/src/main/factories/pages/login/login-factory.tsx
@@ -1,10 +1,15 @@
 import React from 'react'
 import { makeLoginValidation } from './login-validation-factory'
 import { makeRemoteAuthentication } from '@/main/factories/usecases/authentication/remote-authentication-factory'
+import { makeLocalSaveAccessToken } from '@/main/factories/usecases/save-access-token/local-save-access-token-factory'
 import { Login } from '@/presentation/pages'
 
 export const makeLogin: React.FC = () => {
   return (
-    <Login authentication={makeRemoteAuthentication()} validation={makeLoginValidation()} />
+    <Login
+      authentication={makeRemoteAuthentication()}
+      validation={makeLoginValidation()}
+      saveAccessToken={makeLocalSaveAccessToken()}
+    />
   )
 }

--- a/src/main/factories/usecases/save-access-token/local-save-access-token-factory.ts
+++ b/src/main/factories/usecases/save-access-token/local-save-access-token-factory.ts
@@ -1,0 +1,7 @@
+import { LocalSaveAccessToken } from '@/data/usecases/save-access-token/local-save-access-token'
+import { SaveAccessToken } from '@/domain/usecases'
+import { makeLocalStorageAdapter } from '@/main/factories/cache/local-storage-adapter-factory'
+
+export const makeLocalSaveAccessToken = (): SaveAccessToken => {
+  return new LocalSaveAccessToken(makeLocalStorageAdapter())
+}

--- a/src/presentation/pages/login/login.spec.tsx
+++ b/src/presentation/pages/login/login.spec.tsx
@@ -170,6 +170,15 @@ describe('Login Component', () => {
     expect(history.location.pathname).toBe('/')
   })
 
+  test('Should present error if SaveAccessToken fails', async () => {
+    const { sut, saveAccessTokenMock } = makeSut()
+    const error = new InvalidCredentialsError()
+    jest.spyOn(saveAccessTokenMock, 'save').mockRejectedValueOnce(error)
+    await simulateValidSubmit(sut)
+    testElementText(sut, 'main-error', error.message)
+    testErrorWrapChildCount(sut, 1)
+  })
+
   test('Should go to signup page', () => {
     const { sut } = makeSut()
     const register = sut.getByTestId('signup')

--- a/src/presentation/pages/login/login.spec.tsx
+++ b/src/presentation/pages/login/login.spec.tsx
@@ -2,15 +2,15 @@ import React from 'react'
 import { Router } from 'react-router-dom'
 import { createMemoryHistory } from 'history'
 import faker from 'faker'
-import 'jest-localstorage-mock'
 import { render, RenderResult, fireEvent, cleanup, waitFor } from '@testing-library/react'
 import { Login } from '@/presentation/pages'
-import { AuthenticationSpy, ValidationStub } from '@/presentation/test'
+import { AuthenticationSpy, ValidationStub, SaveAccessTokenMock } from '@/presentation/test'
 import { InvalidCredentialsError } from '@/domain/errors'
 
 type SutTypes = {
   sut: RenderResult
   authenticationSpy: AuthenticationSpy
+  saveAccessTokenMock: SaveAccessTokenMock
 }
 
 type SutParams = {
@@ -21,13 +21,19 @@ const history = createMemoryHistory({ initialEntries: ['/login'] })
 const makeSut = (params?: SutParams): SutTypes => {
   const validationStub = new ValidationStub()
   const authenticationSpy = new AuthenticationSpy()
+  const saveAccessTokenMock = new SaveAccessTokenMock()
+
   validationStub.errorMessage = params?.validationError
   const sut = render(
     <Router history={history}>
-      <Login validation={validationStub} authentication={authenticationSpy} />
+      <Login
+        validation={validationStub}
+        authentication={authenticationSpy}
+        saveAccessToken={saveAccessTokenMock}
+      />
     </Router>
   )
-  return { sut, authenticationSpy }
+  return { sut, authenticationSpy, saveAccessTokenMock }
 }
 
 const simulateValidSubmit = async (sut: RenderResult, email = faker.internet.email(), password = faker.internet.password()): Promise<void> => {
@@ -76,9 +82,7 @@ const testButtonIsDisabled = (sut: RenderResult, fieldName: string, isDisabled: 
 
 describe('Login Component', () => {
   afterEach(cleanup)
-  beforeEach(() => {
-    localStorage.clear()
-  })
+
   test('Should start with initial state', () => {
     const validationError = faker.random.words()
     const { sut } = makeSut({ validationError })
@@ -158,10 +162,10 @@ describe('Login Component', () => {
     testErrorWrapChildCount(sut, 1)
   })
 
-  test('Should add accessToken to localstorage on success', async () => {
-    const { sut, authenticationSpy } = makeSut()
+  test('Should call SaveAccessToken on success', async () => {
+    const { sut, authenticationSpy, saveAccessTokenMock } = makeSut()
     await simulateValidSubmit(sut)
-    expect(localStorage.setItem).toHaveBeenCalledWith('accessToken', authenticationSpy.account.accessToken)
+    expect(saveAccessTokenMock.accessToken).toBe(authenticationSpy.account.accessToken)
     expect(history.length).toBe(1)
     expect(history.location.pathname).toBe('/')
   })

--- a/src/presentation/pages/login/login.tsx
+++ b/src/presentation/pages/login/login.tsx
@@ -3,15 +3,16 @@ import Styles from './login-styles.scss'
 import { Footer, Input, LoginHeader, FormStatus } from '@/presentation/components'
 import { FormContext } from '@/presentation/contexts'
 import { Validation } from '@/presentation/protocols/validation'
-import { Authentication } from '@/domain/usecases'
 import { Link, useHistory } from 'react-router-dom'
+import { Authentication, SaveAccessToken } from '@/domain/usecases'
 
 type Props = {
   validation: Validation
   authentication: Authentication
+  saveAccessToken: SaveAccessToken
 }
 
-const Login: React.FC<Props> = ({ validation, authentication }: Props) => {
+const Login: React.FC<Props> = ({ validation, authentication, saveAccessToken }: Props) => {
   const history = useHistory()
   const [state, setState] = useState({
     isLoading: false,
@@ -42,7 +43,7 @@ const Login: React.FC<Props> = ({ validation, authentication }: Props) => {
         email,
         password
       })
-      localStorage.setItem('accessToken', account.accessToken)
+      await saveAccessToken.save(account.accessToken)
       history.replace('/')
     } catch (error) {
       setState({

--- a/src/presentation/test/index.ts
+++ b/src/presentation/test/index.ts
@@ -1,2 +1,3 @@
 export * from './mock-validation'
 export * from './mock-authentication'
+export * from './mock-save-access-token'

--- a/src/presentation/test/mock-save-access-token.ts
+++ b/src/presentation/test/mock-save-access-token.ts
@@ -1,0 +1,9 @@
+import { SaveAccessToken } from '@/domain/usecases/save-access-token'
+
+export class SaveAccessTokenMock implements SaveAccessToken {
+  accessToken: string
+
+  async save (accessToken: string): Promise<void> {
+    this.accessToken = accessToken
+  }
+}

--- a/src/presentation/test/mock-validation.ts
+++ b/src/presentation/test/mock-validation.ts
@@ -3,7 +3,7 @@ import { Validation } from '@/presentation/protocols/validation'
 export class ValidationStub implements Validation {
   errorMessage: string
 
-  validate (): string {
+  validate (fieldName: string, fieldValue: string): string {
     return this.errorMessage
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,7 +54,7 @@ module.exports = {
   plugins: [
     new CleanWebpackPlugin(),
     new DefinePlugin({
-      'process.env.API_URL': 'http://fordevs.herokuapp.com/api'
+      'process.env.API_URL': JSON.stringify('http://fordevs.herokuapp.com/api')
     })
   ]
 }


### PR DESCRIPTION
Add LocalStorage to a separated dedicated  infra adapter and remove it from presentation. To better follow the Clean Architecture Design, the presentation page should not have dependency to an external technology or library and LocalStorage is an example of that.